### PR TITLE
Add IDA Home deal

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This started off as a Black Friday thing last year, but I'm going to try and kee
 | Tools & Services | Heimdalsecurity.com | 75% off Thor | 11/25 | [link](https://heimdalsecurity.com/en/buy/register/thor-premium?voucher=bf75web) |
 | Tools & Services | Lowendbox.com | Offers starting 11/26, Friday deals every 2 hours | 11/25 | [link](https://lowendbox.com/blog/lowendbox-has-mind-blowing-offers-coming-this-black-friday-cyber-monday-season/) |
 | Tools & Services | Particle.io | N/A | 11/25 | N/A |
+| Tools & Services | hex-rays.com | 25% off IDA Home | 11/27 | [link](https://www.hex-rays.com/order/) |
 | | | | | |
 | Products | VMware.com | 30% off products | 11/25 | [link](https://store-us.vmware.com/blackfridaysale) |
 | Products | ESet.com | 40% off products | 11/25 | [link](https://www.eset.com/us/cyber-weekend-2020/) |


### PR DESCRIPTION
hex-rays just sent the following email with a deal on IDA Home:

> Dear RE enthusiast,
>
>You are receiving this email because you have shown some interest in IDA Home and hence we are thrilled to bring you a special offer this Black Friday/ Cyber Monday weekend!
>
>Tune in our Hex-Rays shop at https://www.hex-rays.com/order/
>from 27 to 30 November 2020 to receive a 25% OFF for all IDA Home purchases! 
>
>This is a 4-days-only deal so make sure you mark your calendar, enjoy the shopping and check out this exclusive tool for reverse engineering hobbyists!
>
>**IDA Home is available in 5 different versions and now comes with a compatible cloud-based decompiler (for the 64-bit PC, PPC and ARM versions) in beta testing mode. More information: https://www.hex-rays.com/products/idahome/ida-home-cloud-based-decompilers-beta-testing/
>
>
>We wish you a great holiday, happy shopping and have fun reversing with IDA Home!
